### PR TITLE
Set 'masters = gentoo' for future compatibility

### DIFF
--- a/metadata/layout.conf
+++ b/metadata/layout.conf
@@ -1,1 +1,2 @@
+masters = gentoo
 thin-manifests = true


### PR DESCRIPTION
Repository 'zfs' is missing masters attribute in '/var/lib/layman/zfs/metadata/layout.conf'
